### PR TITLE
fix: build failed without python env on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenCC bindings for Rust
 
 - Clang
 - CMake
-- PYTHON / PYTHON3
+- Python / Python3
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ OpenCC bindings for Rust
 
 - Clang
 - CMake
+- PYTHON / PYTHON3
 
 ## Contributing
 

--- a/opencc-sys/build.rs
+++ b/opencc-sys/build.rs
@@ -7,6 +7,13 @@ fn main() {
 
     let build_type = "Release";
 
+    let is_python3 = env::var("PYTHON3").is_ok();
+
+    let mut python_executable = format!("${{{s}}}", s = "PYTHON");
+    if is_python3 {
+        python_executable = format!("${{{s}}}", s = "PYTHON3");
+    }
+
     cfg = cfg
         .define("CMAKE_BUILD_TYPE", build_type)
         .define("BUILD_DOCUMENTATION", "OFF")
@@ -23,6 +30,7 @@ fn main() {
         .define("USE_SYSTEM_PYBIND11", "OFF")
         .define("USE_SYSTEM_RAPIDJSON", "OFF")
         .define("USE_SYSTEM_TCLAP", "OFF")
+        .define("PYTHON_EXECUTABLE", python_executable)
         .profile(build_type)
         .very_verbose(true);
 


### PR DESCRIPTION
By default, macos will build failed without python.
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/32590310/222617812-1903e7d9-05ff-48fe-bc9a-9a1c3f5403f4.png">
